### PR TITLE
320dp support

### DIFF
--- a/library/src/main/res/layout-w360dp/cpv_dialog_color_picker.xml
+++ b/library/src/main/res/layout-w360dp/cpv_dialog_color_picker.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+  <LinearLayout
+      xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:tools="http://schemas.android.com/tools"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical">
+
+    <com.jrummyapps.android.colorpicker.ColorPickerView
+        android:id="@id/cpv_color_picker_view"
+        style="@style/cpv_ColorPickerViewStyle"
+        android:padding="16dp"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+      <com.jrummyapps.android.colorpicker.ColorPanelView
+          android:id="@id/cpv_color_panel_old"
+          android:layout_width="@dimen/cpv_dialog_preview_width"
+          android:layout_height="@dimen/cpv_dialog_preview_height"
+          app:cpv_colorShape="square"/>
+
+      <ImageView
+          android:id="@+id/cpv_arrow_right"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center_vertical"
+          android:paddingLeft="4dp"
+          android:paddingRight="4dp"
+          android:src="@drawable/cpv_ic_arrow_right_black_24dp"
+          tools:ignore="ContentDescription"/>
+
+      <com.jrummyapps.android.colorpicker.ColorPanelView
+          android:id="@id/cpv_color_panel_new"
+          android:layout_width="@dimen/cpv_dialog_preview_width"
+          android:layout_height="@dimen/cpv_dialog_preview_height"
+          app:cpv_colorShape="square"/>
+
+      <Space
+          android:layout_width="0dp"
+          android:layout_height="0dp"
+          android:layout_weight="1"/>
+
+      <LinearLayout
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginLeft="16dp"
+          android:descendantFocusability="beforeDescendants"
+          android:focusableInTouchMode="true"
+          android:gravity="right"
+          android:orientation="horizontal"
+          tools:ignore="RtlHardcoded">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="#"
+            android:typeface="monospace"
+            tools:ignore="HardcodedText"/>
+
+        <EditText
+            android:id="@+id/cpv_hex"
+            android:layout_width="110dp"
+            android:layout_height="wrap_content"
+            android:digits="0123456789ABCDEFabcdef"
+            android:focusable="true"
+            android:imeOptions="actionGo"
+            android:inputType="textNoSuggestions"
+            android:maxLength="8"
+            android:maxLines="1"
+            android:typeface="monospace"
+            tools:text="88888888"/>
+
+      </LinearLayout>
+
+    </LinearLayout>
+
+  </LinearLayout>
+</ScrollView>

--- a/library/src/main/res/layout/cpv_dialog_color_picker.xml
+++ b/library/src/main/res/layout/cpv_dialog_color_picker.xml
@@ -19,69 +19,68 @@
         android:padding="16dp"/>
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:padding="16dp">
-
-      <com.jrummyapps.android.colorpicker.ColorPanelView
-          android:id="@id/cpv_color_panel_old"
-          android:layout_width="@dimen/cpv_dialog_preview_width"
-          android:layout_height="@dimen/cpv_dialog_preview_height"
-          app:cpv_colorShape="square"/>
-
-      <ImageView
-          android:id="@+id/cpv_arrow_right"
-          android:layout_width="wrap_content"
+          android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_gravity="center_vertical"
-          android:paddingLeft="4dp"
-          android:paddingRight="4dp"
-          android:src="@drawable/cpv_ic_arrow_right_black_24dp"
-          tools:ignore="ContentDescription"/>
+          android:padding="16dp"
+          >
 
-      <com.jrummyapps.android.colorpicker.ColorPanelView
-          android:id="@id/cpv_color_panel_new"
-          android:layout_width="@dimen/cpv_dialog_preview_width"
-          android:layout_height="@dimen/cpv_dialog_preview_height"
-          app:cpv_colorShape="square"/>
+        <com.jrummyapps.android.colorpicker.ColorPanelView
+            android:id="@id/cpv_color_panel_old"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="match_parent"
+            app:cpv_colorShape="square"
+            />
 
-      <Space
-          android:layout_width="0dp"
-          android:layout_height="0dp"
-          android:layout_weight="1"/>
-
-      <LinearLayout
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginLeft="16dp"
-          android:descendantFocusability="beforeDescendants"
-          android:focusableInTouchMode="true"
-          android:gravity="right"
-          android:orientation="horizontal"
-          tools:ignore="RtlHardcoded">
-
-        <TextView
+        <ImageView
+            android:id="@+id/cpv_arrow_right"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="#"
-            android:typeface="monospace"
-            tools:ignore="HardcodedText"/>
+            android:layout_gravity="center_vertical"
+            android:paddingLeft="3dp"
+            android:paddingRight="3dp"
+            android:src="@drawable/cpv_ic_arrow_right_black_24dp"
+            tools:ignore="ContentDescription"/>
 
-        <EditText
-            android:id="@+id/cpv_hex"
-            android:layout_width="110dp"
+        <com.jrummyapps.android.colorpicker.ColorPanelView
+            android:id="@id/cpv_color_panel_new"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="match_parent"
+            app:cpv_colorShape="square"/>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:digits="0123456789ABCDEFabcdef"
-            android:focusable="true"
-            android:imeOptions="actionGo"
-            android:inputType="textNoSuggestions"
-            android:maxLength="8"
-            android:maxLines="1"
-            android:typeface="monospace"/>
+            android:layout_marginLeft="8dp"
+            android:descendantFocusability="beforeDescendants"
+            android:focusableInTouchMode="true"
+            android:gravity="right"
+            android:orientation="horizontal"
+            tools:ignore="RtlHardcoded">
 
-      </LinearLayout>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="#"
+                android:typeface="monospace"
+                tools:ignore="HardcodedText"/>
 
+            <EditText
+                android:id="@+id/cpv_hex"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:digits="0123456789ABCDEFabcdef"
+                android:focusable="true"
+                android:imeOptions="actionGo"
+                android:inputType="textNoSuggestions"
+                android:maxLength="8"
+                android:maxLines="1"
+                android:minWidth="110dp"
+                android:typeface="monospace"
+                tools:text="88888888"/>
+
+        </LinearLayout>
     </LinearLayout>
 
   </LinearLayout>


### PR DESCRIPTION
Maybe this color picker is tested on 360dp or greater width devices,
but Android 7 device settings allows changing pixel density to users.

I'm using Galaxy S8+ and set screen width to 320dp,
EditText does not fit in LinearLayout in the current color picker dialog.

It would be nice to support 320dp width.
Official guidelines says "normal screens are at least 470dp x 320dp","small screens are at least 426dp x 320dp".
there is no reasons to ignore 320dp devices.

I've making PR for support this.
Screen shot:

previous version ( layout error)
![320dp-bad](https://user-images.githubusercontent.com/333944/34282353-1045d042-e708-11e7-8fbd-8a1fd1e499b2.jpg)

modified version (font=normal)
![320dp-font-normal](https://user-images.githubusercontent.com/333944/34282355-139804fe-e708-11e7-8765-4a8e4b95966e.jpg)

modified version (font=largest)
![320dp-font-large](https://user-images.githubusercontent.com/333944/34282358-16b16202-e708-11e7-9484-01cd07a560eb.jpg)

I believe this 320dp layout works also 360dp or greater devices,
but I make layout-w360dp/cpv_dialog_color_picker.xml for compatibility.
If you don't want increasing files to maintain, you can delete it.

Changes:
- make layout-w360dp/cpv_dialog_color_picker.xml. its content is same as previous version
- change layout/cpv_dialog_color_picker.xml that fit to 320dp
-- make EditText's minWidth="110dp", layout_width="wrap_content". it keeps minimum width to 110dp and extend if font size is more big.
-- wrap left part and adjusts its width=0dp, weight=1. 
-- adjust ColorPanelView's width using weight. if right part grow, left part is shrink.
-- adjust ColorPanelView's height to matches parent. It is necessary for really small screen devices


----
please enables issues on your github project.
it's is disabled on default of forked project,
but you can enables it in project settings.
