### PR TITLE
fix ScrollView eats drag event on picker view

### DIFF
--- a/library/src/main/java/com/jrummyapps/android/colorpicker/ColorPickerView.java
+++ b/library/src/main/java/com/jrummyapps/android/colorpicker/ColorPickerView.java
@@ -553,6 +553,12 @@ public class ColorPickerView extends View {
   }
 
   @Override public boolean onTouchEvent(MotionEvent event) {
+  
+    try{
+      this.getParent().requestDisallowInterceptTouchEvent( true );
+    }catch(Throwable ignored){
+    }
+    
     boolean update = false;
 
     switch (event.getAction()) {


### PR DESCRIPTION
I'm using Kyocera's "AndroidOne S2".
Scroll bar is shown in  color picker dialog. it's okay, but ScrollView intercepts touch event on ColorPickerView. Then I can't drag to "real white" because I can't touch really edge picker and I can't drag picking point.

This PR avoids it.
Scrolling is still possible by touching outside of picker view.
