### PR TITLE
Quick select presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ You can add attributes to customize the `ColorPreference`:
 | cpv_allowPresets    | boolean   | true to add a button to toggle to the custom color picker                             |
 | cpv_allowCustom     | boolean   | true to add a button to toggle to the presets color picker                            |
 | cpv_showDialog      | boolean   | true to let the ColorPreference handle showing the dialog                             |
+| cpv_selectOnClick   | boolean   | true to close the dialog when a preset is selected. Only use when cpv_allowCustom=false and cpv_allowPresets=true. |
 
 You can also show a `ColorPickerDialog` without using the `ColorPreference`:
 

--- a/demo/src/main/res/xml/main.xml
+++ b/demo/src/main/res/xml/main.xml
@@ -62,12 +62,24 @@
     <com.jaredrummler.android.colorpicker.ColorPreferenceCompat
         android:defaultValue="0xFFCDDC39"
         android:key="my_presets"
-        android:summary="A picker with presets different presets"
+        android:summary="A picker with different presets"
         android:title="Custom presets"
         app:cpv_allowCustom="false"
         app:cpv_colorPresets="@array/demo_colors"
         app:cpv_previewSize="large"
         app:cpv_showColorShades="false"
+        app:iconSpaceReserved="false"/>
+
+    <com.jaredrummler.android.colorpicker.ColorPreferenceCompat
+        android:defaultValue="0xFF607D8B"
+        android:key="quick_select_presets"
+        android:summary="Same as above, but tapping a color will immediately select the color and close the dialog."
+        android:title="Quick-selection custom presets"
+        app:cpv_allowCustom="false"
+        app:cpv_colorPresets="@array/demo_colors"
+        app:cpv_previewSize="large"
+        app:cpv_showColorShades="false"
+        app:cpv_selectOnClick="true"
         app:iconSpaceReserved="false"/>
 
     <Preference

--- a/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPickerDialog.java
+++ b/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPickerDialog.java
@@ -115,6 +115,7 @@ public class ColorPickerDialog extends DialogFragment implements ColorPickerView
   private static final String ARG_PRESETS_BUTTON_TEXT = "presetsButtonText";
   private static final String ARG_CUSTOM_BUTTON_TEXT = "customButtonText";
   private static final String ARG_SELECTED_BUTTON_TEXT = "selectedButtonText";
+  private static final String ARG_CANCEL_BUTTON_TEXT = "cancelButtonText";
 
   ColorPickerDialogListener colorPickerDialogListener;
   FrameLayout rootView;
@@ -186,7 +187,19 @@ public class ColorPickerDialog extends DialogFragment implements ColorPickerView
 
     AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity()).setView(rootView);
 
-    if (!selectOnClick) {
+    if (selectOnClick) {
+      // Only show a "CANCEL" button to dismiss the window, since no other buttons will be visible
+      int cancelButtonStringRes = getArguments().getInt(ARG_CANCEL_BUTTON_TEXT);
+      if (cancelButtonStringRes == 0) {
+        cancelButtonStringRes = R.string.cpv_cancel;
+      }
+      builder.setNegativeButton(cancelButtonStringRes, new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+          dialog.dismiss();
+        }
+      });
+    } else {
       // Show a SELECT button to confirm selection and close the dialog. Otherwise,
       // just tap the colour to select and close the dialog
       int selectedButtonStringRes = getArguments().getInt(ARG_SELECTED_BUTTON_TEXT);
@@ -754,6 +767,7 @@ public class ColorPickerDialog extends DialogFragment implements ColorPickerView
     @StringRes int presetsButtonText = R.string.cpv_presets;
     @StringRes int customButtonText = R.string.cpv_custom;
     @StringRes int selectedButtonText = R.string.cpv_select;
+    @StringRes int cancelButtonText = R.string.cpv_cancel;
     @DialogType int dialogType = TYPE_PRESETS;
     int[] presets = MATERIAL_COLORS;
     @ColorInt int color = Color.BLACK;
@@ -788,6 +802,17 @@ public class ColorPickerDialog extends DialogFragment implements ColorPickerView
      */
     public Builder setSelectedButtonText(@StringRes int selectedButtonText) {
       this.selectedButtonText = selectedButtonText;
+      return this;
+    }
+
+    /**
+     * Set the cancel button text string resource id
+     *
+     * @param cancelButtonText The string resource used for the cancel button text
+     * @return This builder object for chaining method calls
+     */
+    public Builder setCancelButtonText(@StringRes int cancelButtonText) {
+      this.cancelButtonText = cancelButtonText;
       return this;
     }
 
@@ -948,6 +973,7 @@ public class ColorPickerDialog extends DialogFragment implements ColorPickerView
       args.putInt(ARG_PRESETS_BUTTON_TEXT, presetsButtonText);
       args.putInt(ARG_CUSTOM_BUTTON_TEXT, customButtonText);
       args.putInt(ARG_SELECTED_BUTTON_TEXT, selectedButtonText);
+      args.putInt(ARG_CANCEL_BUTTON_TEXT, cancelButtonText);
       dialog.setArguments(args);
       return dialog;
     }

--- a/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPickerDialog.java
+++ b/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPickerDialog.java
@@ -43,6 +43,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.SeekBar;
 import android.widget.TextView;
+
 import androidx.annotation.ColorInt;
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
@@ -51,6 +52,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.core.graphics.ColorUtils;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
+
 import java.util.Arrays;
 import java.util.Locale;
 
@@ -108,6 +110,7 @@ public class ColorPickerDialog extends DialogFragment implements ColorPickerView
   private static final String ARG_ALLOW_CUSTOM = "allowCustom";
   private static final String ARG_DIALOG_TITLE = "dialogTitle";
   private static final String ARG_SHOW_COLOR_SHADES = "showColorShades";
+  private static final String ARG_SELECT_ON_CLICK = "selectOnClick";
   private static final String ARG_COLOR_SHAPE = "colorShape";
   private static final String ARG_PRESETS_BUTTON_TEXT = "presetsButtonText";
   private static final String ARG_CUSTOM_BUTTON_TEXT = "customButtonText";
@@ -121,6 +124,7 @@ public class ColorPickerDialog extends DialogFragment implements ColorPickerView
   int dialogId;
   boolean showColorShades;
   int colorShape;
+  boolean selectOnClick;
 
   // -- PRESETS --------------------------
   ColorPaletteAdapter adapter;
@@ -163,6 +167,7 @@ public class ColorPickerDialog extends DialogFragment implements ColorPickerView
     dialogId = getArguments().getInt(ARG_ID);
     showAlphaSlider = getArguments().getBoolean(ARG_ALPHA);
     showColorShades = getArguments().getBoolean(ARG_SHOW_COLOR_SHADES);
+    selectOnClick = getArguments().getBoolean(ARG_SELECT_ON_CLICK);
     colorShape = getArguments().getInt(ARG_COLOR_SHAPE);
     if (savedInstanceState == null) {
       color = getArguments().getInt(ARG_COLOR);
@@ -179,17 +184,22 @@ public class ColorPickerDialog extends DialogFragment implements ColorPickerView
       rootView.addView(createPresetsView());
     }
 
-    int selectedButtonStringRes = getArguments().getInt(ARG_SELECTED_BUTTON_TEXT);
-    if (selectedButtonStringRes == 0) {
-      selectedButtonStringRes = R.string.cpv_select;
-    }
+    AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity()).setView(rootView);
 
-    AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity()).setView(rootView)
-        .setPositiveButton(selectedButtonStringRes, new DialogInterface.OnClickListener() {
-          @Override public void onClick(DialogInterface dialog, int which) {
-            onColorSelected(color);
-          }
-        });
+    if (!selectOnClick) {
+      // Show a SELECT button to confirm selection and close the dialog. Otherwise,
+      // just tap the colour to select and close the dialog
+      int selectedButtonStringRes = getArguments().getInt(ARG_SELECTED_BUTTON_TEXT);
+      if (selectedButtonStringRes == 0) {
+        selectedButtonStringRes = R.string.cpv_select;
+      }
+      builder.setPositiveButton(selectedButtonStringRes, new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+          onColorSelected(color);
+        }
+      });
+    }
 
     int dialogTitleStringRes = getArguments().getInt(ARG_DIALOG_TITLE);
     if (dialogTitleStringRes != 0) {
@@ -443,9 +453,9 @@ public class ColorPickerDialog extends DialogFragment implements ColorPickerView
 
     adapter = new ColorPaletteAdapter(new ColorPaletteAdapter.OnColorSelectedListener() {
       @Override public void onColorSelected(int newColor) {
-        if (color == newColor) {
-          // Double tab selects the color
-          ColorPickerDialog.this.onColorSelected(color);
+        if (selectOnClick || color == newColor) {
+          // Double tap selects the color, unless cpv_selectOnClick is enabled in the XML (in which case it's single tap)
+          ColorPickerDialog.this.onColorSelected(newColor);
           dismiss();
           return;
         }
@@ -752,6 +762,7 @@ public class ColorPickerDialog extends DialogFragment implements ColorPickerView
     boolean allowPresets = true;
     boolean allowCustom = true;
     boolean showColorShades = true;
+    boolean selectOnClick = false;
     @ColorShape int colorShape = ColorShape.CIRCLE;
 
     /*package*/ Builder() {
@@ -892,6 +903,18 @@ public class ColorPickerDialog extends DialogFragment implements ColorPickerView
     }
 
     /**
+     * Enable/disable quicker selection of preset colours.
+     * Don't use this unless {@link Builder#allowPresets} is true and {@link Builder#setAllowCustom} is false.
+     *
+     * @param selectOnClick {@code false} to immediately select the colour and close the dialog when clicked.
+     * @return This builder object for chaining method calls
+     */
+    public Builder setSelectOnClick(boolean selectOnClick) {
+      this.selectOnClick = selectOnClick;
+      return this;
+    }
+
+    /**
      * Set the shape of the color panel view.
      *
      * @param colorShape Either {@link ColorShape#CIRCLE} or {@link ColorShape#SQUARE}.
@@ -920,6 +943,7 @@ public class ColorPickerDialog extends DialogFragment implements ColorPickerView
       args.putBoolean(ARG_ALLOW_PRESETS, allowPresets);
       args.putInt(ARG_DIALOG_TITLE, dialogTitle);
       args.putBoolean(ARG_SHOW_COLOR_SHADES, showColorShades);
+      args.putBoolean(ARG_SELECT_ON_CLICK, selectOnClick);
       args.putInt(ARG_COLOR_SHAPE, colorShape);
       args.putInt(ARG_PRESETS_BUTTON_TEXT, presetsButtonText);
       args.putInt(ARG_CUSTOM_BUTTON_TEXT, customButtonText);

--- a/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPreference.java
+++ b/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPreference.java
@@ -43,6 +43,7 @@ public class ColorPreference extends Preference implements ColorPickerDialogList
   private boolean allowCustom;
   private boolean showAlphaSlider;
   private boolean showColorShades;
+  private boolean selectOnClick;
   private int previewSize;
   private int[] presets;
   private int dialogTitle;
@@ -66,6 +67,7 @@ public class ColorPreference extends Preference implements ColorPickerDialogList
     colorShape = a.getInt(R.styleable.ColorPreference_cpv_colorShape, ColorShape.CIRCLE);
     allowPresets = a.getBoolean(R.styleable.ColorPreference_cpv_allowPresets, true);
     allowCustom = a.getBoolean(R.styleable.ColorPreference_cpv_allowCustom, true);
+    selectOnClick = a.getBoolean(R.styleable.ColorPreference_cpv_selectOnClick, false);
     showAlphaSlider = a.getBoolean(R.styleable.ColorPreference_cpv_showAlphaSlider, false);
     showColorShades = a.getBoolean(R.styleable.ColorPreference_cpv_showColorShades, true);
     previewSize = a.getInt(R.styleable.ColorPreference_cpv_previewSize, SIZE_NORMAL);
@@ -100,6 +102,7 @@ public class ColorPreference extends Preference implements ColorPickerDialogList
           .setAllowCustom(allowCustom)
           .setShowAlphaSlider(showAlphaSlider)
           .setShowColorShades(showColorShades)
+          .setSelectOnClick(selectOnClick)
           .setColor(color)
           .create();
       dialog.setColorPickerDialogListener(this);

--- a/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPreferenceCompat.java
+++ b/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPreferenceCompat.java
@@ -28,6 +28,7 @@ public class ColorPreferenceCompat extends Preference implements ColorPickerDial
   private boolean allowCustom;
   private boolean showAlphaSlider;
   private boolean showColorShades;
+  private boolean selectOnClick;
   private int previewSize;
   private int[] presets;
   private int dialogTitle;
@@ -51,6 +52,7 @@ public class ColorPreferenceCompat extends Preference implements ColorPickerDial
     colorShape = a.getInt(R.styleable.ColorPreference_cpv_colorShape, ColorShape.CIRCLE);
     allowPresets = a.getBoolean(R.styleable.ColorPreference_cpv_allowPresets, true);
     allowCustom = a.getBoolean(R.styleable.ColorPreference_cpv_allowCustom, true);
+    selectOnClick = a.getBoolean(R.styleable.ColorPreference_cpv_selectOnClick, false);
     showAlphaSlider = a.getBoolean(R.styleable.ColorPreference_cpv_showAlphaSlider, false);
     showColorShades = a.getBoolean(R.styleable.ColorPreference_cpv_showColorShades, true);
     previewSize = a.getInt(R.styleable.ColorPreference_cpv_previewSize, SIZE_NORMAL);
@@ -85,6 +87,7 @@ public class ColorPreferenceCompat extends Preference implements ColorPickerDial
           .setAllowCustom(allowCustom)
           .setShowAlphaSlider(showAlphaSlider)
           .setShowColorShades(showColorShades)
+          .setSelectOnClick(selectOnClick)
           .setColor(color)
           .create();
       dialog.setColorPickerDialogListener(this);

--- a/library/src/main/res/values-ar/strings.xml
+++ b/library/src/main/res/values-ar/strings.xml
@@ -19,5 +19,6 @@
   <string name="cpv_presets">ألوان جاهزة</string>
   <string name="cpv_custom">ألوان معدلة</string>
   <string name="cpv_select">اختر</string>
+  <string name="cpv_cancel">إلغاء</string>
   <string name="cpv_transparency">الشفافية</string>
 </resources>

--- a/library/src/main/res/values-be/strings.xml
+++ b/library/src/main/res/values-be/strings.xml
@@ -19,5 +19,6 @@
     <string name="cpv_presets">Перадусталёўкі</string>
     <string name="cpv_custom">Асаблівы</string>
     <string name="cpv_select">Выбраць</string>
+    <string name="cpv_cancel">адмяніць</string>
     <string name="cpv_transparency">Празрыстасць</string>
 </resources>

--- a/library/src/main/res/values-cs/strings.xml
+++ b/library/src/main/res/values-cs/strings.xml
@@ -19,5 +19,6 @@
   <string name="cpv_presets">Přednastavené</string>
   <string name="cpv_custom">Vlastní</string>
   <string name="cpv_select">Vybrat</string>
+  <string name="cpv_cancel">Zrušení</string>
   <string name="cpv_transparency">Průhlednost</string>
 </resources>

--- a/library/src/main/res/values-de/strings.xml
+++ b/library/src/main/res/values-de/strings.xml
@@ -19,5 +19,6 @@
   <string name="cpv_presets">Voreinstellungen</string>
   <string name="cpv_custom">Benutzerdefiniert</string>
   <string name="cpv_select">Auswählen</string>
+  <string name="cpv_cancel">Stornieren</string>
   <string name="cpv_transparency">Transparenz</string>
 </resources>

--- a/library/src/main/res/values-es/strings.xml
+++ b/library/src/main/res/values-es/strings.xml
@@ -5,5 +5,6 @@
   <string name="cpv_presets">Predeterminados</string>
   <string name="cpv_custom">Personalizar</string>
   <string name="cpv_select">Seleccionar</string>
+  <string name="cpv_cancel">Cancelar</string>
   <string name="cpv_transparency">Transparencia</string>
 </resources>

--- a/library/src/main/res/values-fr-rFR/strings.xml
+++ b/library/src/main/res/values-fr-rFR/strings.xml
@@ -16,5 +16,6 @@
   <string name="cpv_presets">Présélections</string>
   <string name="cpv_custom">Personnalisée</string>
   <string name="cpv_select">Valider</string>
+  <string name="cpv_cancel">Annuler</string>
   <string name="cpv_transparency">Transparence</string>
 </resources>

--- a/library/src/main/res/values-it-rIT/strings.xml
+++ b/library/src/main/res/values-it-rIT/strings.xml
@@ -18,5 +18,6 @@
   <string name="cpv_default_title">Seleziona un Colore</string>
   <string name="cpv_presets">Predefiniti</string>
   <string name="cpv_select">Seleziona</string>
+  <string name="cpv_cancel">Annulla</string>
   <string name="cpv_transparency">Trasparenza</string>
 </resources>

--- a/library/src/main/res/values-iw/strings.xml
+++ b/library/src/main/res/values-iw/strings.xml
@@ -4,5 +4,6 @@
     <string name="cpv_presets">קבוע מראש</string>
     <string name="cpv_custom">מותאם אישית</string>
     <string name="cpv_select">בחירה</string>
+    <string name="cpv_cancel">לְבַטֵל</string>
     <string name="cpv_transparency">שקיפות</string>
 </resources>

--- a/library/src/main/res/values-ja/strings.xml
+++ b/library/src/main/res/values-ja/strings.xml
@@ -19,5 +19,6 @@
   <string name="cpv_presets">プリセット</string>
   <string name="cpv_custom">カスタム</string>
   <string name="cpv_select">選択</string>
+  <string name="cpv_cancel">キャンセル</string>
   <string name="cpv_transparency">透明度</string>
 </resources>

--- a/library/src/main/res/values-nl-rNL/strings.xml
+++ b/library/src/main/res/values-nl-rNL/strings.xml
@@ -16,5 +16,6 @@
   <string name="cpv_presets">Vooraf ingesteld</string>
   <string name="cpv_custom">Aangepast</string>
   <string name="cpv_select">Kiezen</string>
+  <string name="cpv_cancel">Annuleren</string>
   <string name="cpv_transparency">Transparantie</string>
 </resources>

--- a/library/src/main/res/values-pl/strings.xml
+++ b/library/src/main/res/values-pl/strings.xml
@@ -19,5 +19,6 @@
   <string name="cpv_presets">Kolory domyślne</string>
   <string name="cpv_custom">Dostosuj</string>
   <string name="cpv_select">Wybierz</string>
+  <string name="cpv_cancel">Anulować</string>
   <string name="cpv_transparency">Przezroczystość</string>
 </resources>

--- a/library/src/main/res/values-pt/strings.xml
+++ b/library/src/main/res/values-pt/strings.xml
@@ -5,5 +5,6 @@
   <string name="cpv_presets">Predefinidos</string>
   <string name="cpv_custom">Personalizar</string>
   <string name="cpv_select">Selecionar</string>
+  <string name="cpv_cancel">Cancelar</string>
   <string name="cpv_transparency">Transparência</string>
 </resources>

--- a/library/src/main/res/values-ru/strings.xml
+++ b/library/src/main/res/values-ru/strings.xml
@@ -19,5 +19,6 @@
   <string name="cpv_presets">Предустановки</string>
   <string name="cpv_custom">Особый</string>
   <string name="cpv_select">Выбрать</string>
+  <string name="cpv_cancel">Отмена</string>
   <string name="cpv_transparency">Прозрачность</string>
 </resources>

--- a/library/src/main/res/values-sk/strings.xml
+++ b/library/src/main/res/values-sk/strings.xml
@@ -19,5 +19,6 @@
   <string name="cpv_presets">Prednastavené</string>
   <string name="cpv_custom">Vlastné</string>
   <string name="cpv_select">Vybrať</string>
+  <string name="cpv_cancel">Zrušiť</string>
   <string name="cpv_transparency">Priehľadnosť</string>
 </resources>

--- a/library/src/main/res/values-tr/strings.xml
+++ b/library/src/main/res/values-tr/strings.xml
@@ -16,5 +16,6 @@
   <string name="cpv_presets">Ön Ayarlar</string>
   <string name="cpv_custom">Özel</string>
   <string name="cpv_select">Seç</string>
+  <string name="cpv_cancel">İptal etmek</string>
   <string name="cpv_transparency">Şeffaflık</string>
 </resources>

--- a/library/src/main/res/values-zh/strings.xml
+++ b/library/src/main/res/values-zh/strings.xml
@@ -19,5 +19,6 @@
   <string name="cpv_presets">预置颜色</string>
   <string name="cpv_custom">自定义颜色</string>
   <string name="cpv_select">确认</string>
+  <string name="cpv_cancel">取消</string>
   <string name="cpv_transparency">透明度</string>
 </resources>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -33,6 +33,7 @@
     <attr format="boolean|reference" name="cpv_allowPresets"/>
     <attr format="boolean|reference" name="cpv_allowCustom"/>
     <attr format="boolean|reference" name="cpv_showDialog"/>
+    <attr format="boolean|reference" name="cpv_selectOnClick"/>
   </declare-styleable>
 
 </resources>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -19,5 +19,6 @@
   <string name="cpv_presets">Presets</string>
   <string name="cpv_custom">Custom</string>
   <string name="cpv_select">Select</string>
+  <string name="cpv_cancel">Cancel</string>
   <string name="cpv_transparency">Transparency</string>
 </resources>


### PR DESCRIPTION
By adding  `app:cpv_selectOnClick="true"` to the XML declaration, you can now enable single-tap selection of colours in a preset window. If this is enabled, the "SELECT" dialog button is replaced by a "CANCEL" button to dismiss the dialog. Note that the included translations for this new button are ripped straight from Google Translate, I fully expect there to be issues with these.

Of course if you intend on using any more complex functions (alpha scale, colour shading, custom colour-picking, etc.) this option is not for you, this is just for choosing from a restricted selection of colour presets.

I only did this for my own uses and thought it might be a neat option to include in the main repo.